### PR TITLE
Allow for more generic mail relay config and associated authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ The state in which the Postfix service should be after this role runs, and wheth
 
 Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
 
-    postfix_relay_to_mailhog: no
+    postfix_relayhost: [smp.google.com]:587
+    postfix_relay_username: user
+    postfix_relay_password: !vault | $ANSIBLE_VAULT;1.1;AES256...
 
-Option to enable relaying to MailHog on the localhost, port 1025. Requires [MailHog](https://github.com/geerlingguy/ansible-role-mailhog) to be installed on localhost.
+Option to enable relaying to a remote host, optionally with smtp authentication. You will need to set Postfix smtp sasl
+configuration values to ensure that the type of authentication you need is available and used.
+
+Relay could also be MailHog on the localhost, port 1025. See [MailHog](https://github.com/geerlingguy/ansible-role-mailhog).
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,9 @@
 ---
 postfix_config_file: /etc/postfix/main.cf
+postfix_relay_credentials: /etc/postfix/relay_credentials
 
 postfix_service_state: started
 postfix_service_enabled: yes
 
 postfix_inet_interfaces: localhost
 postfix_inet_protocols: all
-
-postfix_relay_to_mailhog: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart postfix
   service: name=postfix state=restarted
+
+- name: rehash credentials
+  shell: "postmap hash:{{ postfix_relay_credentials }}"
+  notify: restart postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,14 @@
     name: postfix
     state: present
 
+- name: Ensure cyrus-sasl is installed.
+  package:
+    name:
+    - cyrus-sasl-lib
+    - cyrus-sasl-plain
+  state: present
+  when: postfix_relay_username is defined and postfix_relay_password is defined
+
 - name: Update Postfix configuration.
   lineinfile:
     dest: "{{ postfix_config_file }}"
@@ -16,13 +24,24 @@
       value: "{{ postfix_inet_protocols }}"
   notify: restart postfix
 
-- name: Enable relay to MailHog.
+- name: Enable relay to an external host.
   lineinfile:
     dest: "{{ postfix_config_file }}"
-    line: "relayhost = 127.0.0.1:1025"
+    line: "relayhost = {{ postfix_relayhost }}"
     regexp: "^relayhost ="
-  when: postfix_relay_to_mailhog
+  when: postfix_relayhost is defined
   notify: restart postfix
+
+- name: Update Postfix relayhost credentials.
+  tags:
+    - postfix
+  lineinfile:
+    dest: "{{ postfix_relay_credentials }}"
+    line: "{{ postfix_relayhost }} {{ postfix_relay_username }}:{{ postfix_relay_password }}"
+    regexp: "^{{ postfix_relayhost }} "
+    mode: 0640
+  when: postfix_relayhost is defined and postfix_relay_username is defined and postfix_relay_password is defined
+  notify: rehash credentials
 
 - name: Ensure postfix is started and enabled at boot.
   service:


### PR DESCRIPTION
I use this config myself, but it is combined with the more generic postfix config management in https://github.com/cafuego/ansible-role-postfix/tree/all-the-settings